### PR TITLE
add IFTTTTransformAnimation

### DIFF
--- a/src/IFTTTAnimationFrame.h
+++ b/src/IFTTTAnimationFrame.h
@@ -12,5 +12,6 @@
 @property (nonatomic) CGFloat alpha;
 @property (nonatomic) BOOL hidden;
 @property (nonatomic) UIColor * color;
+@property (nonatomic) CGAffineTransform transform;
 
 @end

--- a/src/IFTTTAnimationKeyFrame.h
+++ b/src/IFTTTAnimationKeyFrame.h
@@ -22,16 +22,19 @@
 + (NSArray *)keyFramesWithTimesAndFrames:(NSInteger)pairCount,...;
 + (NSArray *)keyFramesWithTimesAndHiddens:(NSInteger)pairCount,...;
 + (NSArray *)keyFramesWithTimesAndColors:(NSInteger)pairCount,...;
++ (NSArray *)keyFramesWithTimesAndTransforms:(NSInteger)pairCount,...;
 
 + (instancetype)keyFrameWithTime:(NSInteger)time andAlpha:(CGFloat)alpha;
 + (instancetype)keyFrameWithTime:(NSInteger)time andFrame:(CGRect)frame;
 + (instancetype)keyFrameWithTime:(NSInteger)time andHidden:(BOOL)hidden;
 + (instancetype)keyFrameWithTime:(NSInteger)time andColor:(UIColor*)color;
++ (instancetype)keyFrameWithTime:(NSInteger)time andTransform:(CGAffineTransform)transform;
 
 - (id)initWithTime:(NSInteger)time andAlpha:(CGFloat)alpha;
 - (id)initWithTime:(NSInteger)time andFrame:(CGRect)frame;
 - (id)initWithTime:(NSInteger)time andHidden:(BOOL)hidden;
 - (id)initWithTime:(NSInteger)time andColor:(UIColor*)color;
+- (id)initWithTime:(NSInteger)time andTransform:(CGAffineTransform)transform;
 
 @property (assign, nonatomic) NSInteger time;
 

--- a/src/IFTTTAnimationKeyFrame.m
+++ b/src/IFTTTAnimationKeyFrame.m
@@ -118,6 +118,32 @@
     }
 }
 
++ (NSArray *)keyFramesWithTimesAndTransforms:(NSInteger)pairCount,...{
+    va_list argumentList;
+    NSInteger time;
+    CGAffineTransform transform;
+    if (pairCount > 0) {
+        NSMutableArray *keyFrames = [NSMutableArray arrayWithCapacity:pairCount];
+
+        va_start(argumentList, pairCount);
+
+        for (int i=0; i<pairCount; i++) {
+            time = va_arg(argumentList, NSInteger);
+            transform = va_arg(argumentList, CGAffineTransform);
+            IFTTTAnimationKeyFrame *keyFrame = [IFTTTAnimationKeyFrame keyFrameWithTime: time
+                                                                           andTransform: transform];
+            [keyFrames addObject:keyFrame];
+        }
+
+        va_end(argumentList);
+
+        return [NSArray arrayWithArray:keyFrames];
+    }
+    else {
+        return nil;
+    }
+}
+
 + (instancetype)keyFrameWithTime:(NSInteger)time andAlpha:(CGFloat)alpha
 {
     IFTTTAnimationKeyFrame *keyFrame = [[[self class] alloc] initWithTime: time
@@ -143,6 +169,12 @@
 {
     IFTTTAnimationKeyFrame *keyFrame = [[[self class] alloc] initWithTime: time
                                                                  andColor: color];
+    return keyFrame;
+}
+
++ (instancetype)keyFrameWithTime:(NSInteger)time andTransform:(CGAffineTransform)transform {
+    IFTTTAnimationKeyFrame *keyFrame = [[[self class] alloc] initWithTime: time
+                                                             andTransform: transform];
     return keyFrame;
 }
 
@@ -198,6 +230,17 @@
         self.color = color;
     }
     
+    return self;
+}
+
+- (id)initWithTime:(NSInteger)time andTransform:(CGAffineTransform)transform
+{
+    self = [self initWithTime:time];
+
+    if (self) {
+        self.transform = transform;
+    }
+
     return self;
 }
 

--- a/src/IFTTTJazzHands.h
+++ b/src/IFTTTJazzHands.h
@@ -13,3 +13,4 @@
 #import "IFTTTFrameAnimation.h"
 #import "IFTTTHideAnimation.h"
 #import "IFTTTColorAnimation.h"
+#import "IFTTTTransformAnimation.h"

--- a/src/IFTTTTransformAnimation.h
+++ b/src/IFTTTTransformAnimation.h
@@ -1,0 +1,11 @@
+//
+// Created by hayashi311 on 11/10/13.
+// Copyright (c) 2013 IFTTT Inc. All rights reserved.
+//
+
+
+#import "IFTTTAnimation.h"
+
+@interface IFTTTTransformAnimation : IFTTTAnimation
+
+@end

--- a/src/IFTTTTransformAnimation.m
+++ b/src/IFTTTTransformAnimation.m
@@ -1,0 +1,44 @@
+//
+// Created by hayashi311 on 11/10/13.
+// Copyright (c) 2013 IFTTT Inc. All rights reserved.
+//
+
+
+#import "IFTTTTransformAnimation.h"
+
+
+@implementation IFTTTTransformAnimation {
+
+}
+
+- (void)animate:(NSInteger)time
+{
+    if (self.keyFrames.count <= 1) return;
+
+    IFTTTAnimationFrame *animationFrame = [self animationFrameForTime:time];
+    self.view.transform = animationFrame.transform;
+}
+
+- (IFTTTAnimationFrame *)frameForTime:(NSInteger)time
+                        startKeyFrame:(IFTTTAnimationKeyFrame *)startKeyFrame
+                          endKeyFrame:(IFTTTAnimationKeyFrame *)endKeyFrame
+{
+    NSInteger startTime = startKeyFrame.time;
+    NSInteger endTime = endKeyFrame.time;
+    CGAffineTransform startTransform = startKeyFrame.transform;
+    CGAffineTransform endTransform = endKeyFrame.transform;
+
+    CGAffineTransform transform = CGAffineTransformIdentity;
+    transform.a = [self tweenValueForStartTime:startTime endTime:endTime startValue:startTransform.a endValue:endTransform.a atTime:time];
+    transform.b = [self tweenValueForStartTime:startTime endTime:endTime startValue:startTransform.b endValue:endTransform.b atTime:time];
+    transform.c = [self tweenValueForStartTime:startTime endTime:endTime startValue:startTransform.c endValue:endTransform.c atTime:time];
+    transform.d = [self tweenValueForStartTime:startTime endTime:endTime startValue:startTransform.d endValue:endTransform.d atTime:time];
+    transform.tx = [self tweenValueForStartTime:startTime endTime:endTime startValue:startTransform.tx endValue:endTransform.tx atTime:time];
+    transform.ty = [self tweenValueForStartTime:startTime endTime:endTime startValue:startTransform.ty endValue:endTransform.ty atTime:time];
+
+    IFTTTAnimationFrame *animationFrame = [IFTTTAnimationFrame new];
+    animationFrame.transform = transform;
+
+    return animationFrame;
+}
+@end


### PR DESCRIPTION
# IFTTTTransformAnimation

## Add IFTTTTransformAnimation

IFTTTTransformAnimation Class can realize the animation with CGAffineTransform.

## Background
I think -(void)setTransform is better than -(void)setFrame:.

When you use -(void)setFrame:, many subclass of UIView like UILabel or UIButton call -(void)setNeedDisplay;

As you may know, UIKit is based on Text Kit from iOS7.
Text Kit is grate. but, high cost.

https://developer.apple.com/library/ios/documentation/StringsTextFonts/Conceptual/TextAndWebiPhoneOS/CustomTextProcessing/CustomTextProcessing.html

Using IFTTTFrameAnimation with UILabel instance cause excessive drawing.
I mean, Text Kit draw text every frame.

Thus, using many UIlabel makes scroll not smooth.

How do you think about it?