### PR TITLE
NOT round the value of origin of an animating frame. 

### DIFF
--- a/src/IFTTTFrameAnimation.m
+++ b/src/IFTTTFrameAnimation.m
@@ -39,12 +39,12 @@
     CGRect frame = self.view.frame;
     frame.origin.x = [self tweenValueForStartTime:startTime endTime:endTime startValue:CGRectGetMinX(startLocation) endValue:CGRectGetMinX(endLocation) atTime:time];
     frame.origin.y = [self tweenValueForStartTime:startTime endTime:endTime startValue:CGRectGetMinY(startLocation) endValue:CGRectGetMinY(endLocation) atTime:time];
-    frame.size.width = [self tweenValueForStartTime:startTime endTime:endTime startValue:CGRectGetWidth(startLocation) endValue:CGRectGetWidth(endLocation) atTime:time];
-    frame.size.height = [self tweenValueForStartTime:startTime endTime:endTime startValue:CGRectGetHeight(startLocation) endValue:CGRectGetHeight(endLocation) atTime:time];
+    frame.size.width = [self tweenValueForStartTime:startTime endTime:endTime startValue:CGRectGetWidth(startLocation) endValue:CGRectGetWidth(endLocation) atTime:time] ? : 0;
+    frame.size.height = [self tweenValueForStartTime:startTime endTime:endTime startValue:CGRectGetHeight(startLocation) endValue:CGRectGetHeight(endLocation) atTime:time] ? : 0;
 
     IFTTTAnimationFrame *animationFrame = [IFTTTAnimationFrame new];
-    animationFrame.frame = CGRectIntegral(frame);
-    
+    animationFrame.frame = frame;
+
     return animationFrame;
 }
 


### PR DESCRIPTION
If we round the `origin` of `frame`, view may "shake" when animating.
