### PR TITLE
Easing function

### DIFF
--- a/JazzHandsDemo/JazzHandsDemo/IFTTTJazzHandsViewController.m
+++ b/JazzHandsDemo/JazzHandsDemo/IFTTTJazzHandsViewController.m
@@ -129,7 +129,11 @@
     [self.animator addAnimation:wordmarkFrameAnimation];
 
     [wordmarkFrameAnimation addKeyFrames:@[
-        [IFTTTAnimationKeyFrame keyFrameWithTime:timeForPage(1) andFrame:CGRectOffset(self.wordmark.frame, 200, 0)],
+        ({
+            IFTTTAnimationKeyFrame *keyFrame = [IFTTTAnimationKeyFrame keyFrameWithTime:timeForPage(1) andFrame:CGRectOffset(self.wordmark.frame, 200, 0)];
+            keyFrame.easingFunction = IFTTTEasingFunctionEaseInQuart;
+            keyFrame;
+        }),
         [IFTTTAnimationKeyFrame keyFrameWithTime:timeForPage(2) andFrame:self.wordmark.frame],
         [IFTTTAnimationKeyFrame keyFrameWithTime:timeForPage(3) andFrame:CGRectOffset(self.wordmark.frame, self.view.frame.size.width, dy)],
         [IFTTTAnimationKeyFrame keyFrameWithTime:timeForPage(4) andFrame:CGRectOffset(self.wordmark.frame, 0, dy)],

--- a/src/IFTTTAnimation.m
+++ b/src/IFTTTAnimation.m
@@ -74,9 +74,17 @@
     for (NSUInteger i = 0; i < self.keyFrames.count - 1; i++) {
         IFTTTAnimationKeyFrame *currentKeyFrame = self.keyFrames[i];
         IFTTTAnimationKeyFrame *nextKeyFrame = self.keyFrames[i+1];
-        
-        for (NSInteger j = currentKeyFrame.time + (i == 0 ? 0 : 1); j <= nextKeyFrame.time; j++) {
-            [self.timeline addObject:[self frameForTime:j
+        IFTTTEasingFunction easingFunction = currentKeyFrame.easingFunction;
+
+        NSInteger startTime = currentKeyFrame.time;
+        NSInteger endTime = nextKeyFrame.time;
+        NSInteger duration = endTime - startTime;
+
+        for (NSInteger currentTime = (i == 0 ? 0 : 1); currentTime <= duration; currentTime++) {
+            CGFloat fraction = (CGFloat)currentTime / (CGFloat)duration;
+            NSInteger time = startTime + easingFunction(fraction) * (CGFloat)duration;
+
+            [self.timeline addObject:[self frameForTime:time
                                           startKeyFrame:currentKeyFrame
                                             endKeyFrame:nextKeyFrame]];
         }

--- a/src/IFTTTAnimationKeyFrame.h
+++ b/src/IFTTTAnimationKeyFrame.h
@@ -7,6 +7,7 @@
 //
 
 #import "IFTTTAnimationFrame.h"
+#import "IFTTTEasingFunction.h"
 
 @interface IFTTTAnimationKeyFrame : IFTTTAnimationFrame
 
@@ -47,5 +48,6 @@
 - (id)initWithTime:(NSInteger)time andConstraint:(CGFloat)constraint;
 
 @property (assign, nonatomic) NSInteger time;
+@property (copy, nonatomic) IFTTTEasingFunction easingFunction;
 
 @end

--- a/src/IFTTTAnimationKeyFrame.m
+++ b/src/IFTTTAnimationKeyFrame.m
@@ -284,6 +284,7 @@
     
     if (self) {
         self.time = time;
+        self.easingFunction = IFTTTEasingFunctionLinear;
     }
     
     return self;

--- a/src/IFTTTEasingFunction.h
+++ b/src/IFTTTEasingFunction.h
@@ -1,0 +1,31 @@
+//
+//  IFTTTEasingFunction.h
+//  JazzHands
+//
+//  Created by Felix Jendrusch on 1/9/15.
+//
+//
+
+// Copied from Robert Böhnke's RBBAnimation, original available here:
+// <https://github.com/robb/RBBAnimation/blob/a29cafe2fa91e62573cc9967990b0ad2a6b17a76/RBBAnimation/RBBEasingFunction.h>
+
+#import <QuartzCore/QuartzCore.h>
+
+typedef CGFloat (^IFTTTEasingFunction)(CGFloat t);
+
+extern IFTTTEasingFunction const IFTTTEasingFunctionLinear;
+
+extern IFTTTEasingFunction const IFTTTEasingFunctionEaseInQuad;
+extern IFTTTEasingFunction const IFTTTEasingFunctionEaseOutQuad;
+extern IFTTTEasingFunction const IFTTTEasingFunctionEaseInOutQuad;
+
+extern IFTTTEasingFunction const IFTTTEasingFunctionEaseInCubic;
+extern IFTTTEasingFunction const IFTTTEasingFunctionEaseOutCubic;
+extern IFTTTEasingFunction const IFTTTEasingFunctionEaseInOutCubic;
+
+extern IFTTTEasingFunction const IFTTTEasingFunctionEaseInQuart;
+extern IFTTTEasingFunction const IFTTTEasingFunctionEaseOutQuart;
+extern IFTTTEasingFunction const IFTTTEasingFunctionEaseInOutQuart;
+
+extern IFTTTEasingFunction const IFTTTEasingFunctionEaseInBounce;
+extern IFTTTEasingFunction const IFTTTEasingFunctionEaseOutBounce;

--- a/src/IFTTTEasingFunction.m
+++ b/src/IFTTTEasingFunction.m
@@ -1,0 +1,90 @@
+//
+//  IFTTTEasingFunction.m
+//  JazzHands
+//
+//  Created by Felix Jendrusch on 1/9/15.
+//
+//
+
+// Copied from Robert Böhnke's RBBAnimation, original available here:
+// <https://github.com/robb/RBBAnimation/blob/a29cafe2fa91e62573cc9967990b0ad2a6b17a76/RBBAnimation/RBBEasingFunction.m>
+
+#import "IFTTTEasingFunction.h"
+
+#if CGFLOAT_IS_DOUBLE
+#define POW(X, Y) pow(X, Y)
+#else
+#define POW(X, Y) powf(X, Y)
+#endif
+
+IFTTTEasingFunction const IFTTTEasingFunctionLinear = ^(CGFloat t) {
+    return t;
+};
+
+IFTTTEasingFunction const IFTTTEasingFunctionEaseInQuad = ^(CGFloat t) {
+    return t * t;
+};
+
+IFTTTEasingFunction const IFTTTEasingFunctionEaseOutQuad = ^(CGFloat t) {
+    return t * (2 - t);
+};
+
+IFTTTEasingFunction const IFTTTEasingFunctionEaseInOutQuad = ^(CGFloat t) {
+    if (t < 0.5) {
+        return 2 * t * t;
+    } else {
+        return -1 + (4 - 2 * t) * t;
+    }
+};
+
+IFTTTEasingFunction const IFTTTEasingFunctionEaseInCubic = ^(CGFloat t) {
+    return t * t * t;
+};
+
+IFTTTEasingFunction const IFTTTEasingFunctionEaseOutCubic = ^(CGFloat t) {
+    return POW(t - 1, 3) + 1;
+};
+
+IFTTTEasingFunction const IFTTTEasingFunctionEaseInOutCubic = ^(CGFloat t) {
+    if (t < 0.5) {
+        return 4 * POW(t, 3);
+    } else {
+        return (t - 1) * POW(2 * t - 2, 2) + 1;
+    }
+};
+
+IFTTTEasingFunction const IFTTTEasingFunctionEaseInQuart = ^(CGFloat t) {
+    return t * t * t * t;
+};
+
+IFTTTEasingFunction const IFTTTEasingFunctionEaseOutQuart = ^(CGFloat t) {
+    return POW(t - 1, 4) + 1;
+};
+
+IFTTTEasingFunction const IFTTTEasingFunctionEaseInOutQuart = ^(CGFloat t) {
+    if (t < 0.5) {
+        return 8 * POW(t, 4);
+    } else {
+        return -1 / 2 * POW(2 * t - 2, 4) + 1;
+    }
+};
+
+IFTTTEasingFunction const IFTTTEasingFunctionEaseInBounce = ^CGFloat(CGFloat t) {
+    return 1.0 - IFTTTEasingFunctionEaseOutBounce(1.0 - t);
+};
+
+IFTTTEasingFunction const IFTTTEasingFunctionEaseOutBounce = ^CGFloat(CGFloat t) {
+    if (t < 4.0 / 11.0) {
+        return POW(11.0 / 4.0, 2) * POW(t, 2);
+    }
+
+    if (t < 8.0 / 11.0) {
+        return 3.0 / 4.0 + POW(11.0 / 4.0, 2) * POW(t - 6.0 / 11.0, 2);
+    }
+
+    if (t < 10.0 / 11.0) {
+        return 15.0 /16.0 + POW(11.0 / 4.0, 2) * POW(t - 9.0 / 11.0, 2);
+    }
+
+    return 63.0 / 64.0 + POW(11.0 / 4.0, 2) * POW(t - 21.0 / 22.0, 2);
+};


### PR DESCRIPTION
This adds the ability to set an easing function on all animations between any two consecutive key frames. For two consecutive key frames `A` and `B`, `A`'s easing function is used for tweening values between `A` and `B`.

Several standard easing functions are provided (@robb, thx): linear (default), ease in (quad, cubic, quart, bounce), ease out (quad, cubic, quart, bounce), ease in and out (quad, cubic, quart).

🏄