### PR TITLE
CAShapeLayer: strokeStart, strokeEnd, fillColor properties animation

### DIFF
--- a/Example/Pods/Headers/Private/JazzHands/IFTTTFillColorAnimation.h
+++ b/Example/Pods/Headers/Private/JazzHands/IFTTTFillColorAnimation.h
@@ -1,0 +1,1 @@
+../../../../../JazzHands/IFTTTFillColorAnimation.h

--- a/Example/Pods/Headers/Private/JazzHands/IFTTTStrokeEndAnimation.h
+++ b/Example/Pods/Headers/Private/JazzHands/IFTTTStrokeEndAnimation.h
@@ -1,0 +1,1 @@
+../../../../../JazzHands/IFTTTStrokeEndAnimation.h

--- a/Example/Pods/Headers/Private/JazzHands/IFTTTStrokeStartAnimation.h
+++ b/Example/Pods/Headers/Private/JazzHands/IFTTTStrokeStartAnimation.h
@@ -1,0 +1,1 @@
+../../../../../JazzHands/IFTTTStrokeStartAnimation.h

--- a/Example/Pods/Headers/Public/JazzHands/IFTTTFillColorAnimation.h
+++ b/Example/Pods/Headers/Public/JazzHands/IFTTTFillColorAnimation.h
@@ -1,0 +1,1 @@
+../../../../../JazzHands/IFTTTFillColorAnimation.h

--- a/Example/Pods/Headers/Public/JazzHands/IFTTTStrokeEndAnimation.h
+++ b/Example/Pods/Headers/Public/JazzHands/IFTTTStrokeEndAnimation.h
@@ -1,0 +1,1 @@
+../../../../../JazzHands/IFTTTStrokeEndAnimation.h

--- a/Example/Pods/Headers/Public/JazzHands/IFTTTStrokeStartAnimation.h
+++ b/Example/Pods/Headers/Public/JazzHands/IFTTTStrokeStartAnimation.h
@@ -1,0 +1,1 @@
+../../../../../JazzHands/IFTTTStrokeStartAnimation.h

--- a/JazzHands/IFTTTAnimation.h
+++ b/JazzHands/IFTTTAnimation.h
@@ -13,12 +13,15 @@
 @interface IFTTTAnimation : NSObject
 
 @property (strong, nonatomic) UIView *view;
+@property (strong, nonatomic) CALayer *layer;
 @property (strong, nonatomic) NSLayoutConstraint *constraint;
 @property (strong, nonatomic) NSMutableArray *keyFrames;
 
 + (instancetype)animationWithView:(UIView *)view;
++ (instancetype)animationWithLayer:(CALayer *)layer;
 
 - (id)initWithView:(UIView *)view;
+- (id)initWithLayer:(CALayer *)layer;
 
 - (void)animate:(NSInteger)time;
 

--- a/JazzHands/IFTTTAnimation.m
+++ b/JazzHands/IFTTTAnimation.m
@@ -24,6 +24,11 @@
     return [[self alloc] initWithView:view];
 }
 
++ (instancetype)animationWithLayer:(CALayer *)layer
+{
+    return [(IFTTTAnimation *)[self alloc] initWithLayer:layer];
+}
+
 - (id)init
 {
     if ((self = [super init])) {
@@ -39,6 +44,15 @@
 {
     if ((self = [self init])) {
         self.view = view;
+    }
+    
+    return self;
+}
+
+- (id)initWithLayer:(CALayer *)layer
+{
+    if ((self = [self init])) {
+        self.layer = layer;
     }
     
     return self;

--- a/JazzHands/IFTTTAnimationFrame.h
+++ b/JazzHands/IFTTTAnimationFrame.h
@@ -21,4 +21,7 @@
 @property (nonatomic, assign) CGFloat scale;
 @property (nonatomic, assign) CGFloat constraintConstant;
 
+@property (nonatomic, assign) CGFloat strokeStart;
+@property (nonatomic, assign) CGFloat strokeEnd;
+
 @end

--- a/JazzHands/IFTTTAnimationKeyFrame.h
+++ b/JazzHands/IFTTTAnimationKeyFrame.h
@@ -28,6 +28,8 @@
 + (NSArray *)keyFramesWithTimesAndTransform3D:(NSInteger)pairCount,...;
 + (NSArray *)keyFramesWithTimesAndScales:(NSInteger)pairCount,...;
 + (NSArray *)keyFramesWithTimesAndConstraint:(NSInteger)pairCount,...;
++ (NSArray *)keyFramesWithTimesAndStrokeStarts:(NSInteger)pairCount,...;
++ (NSArray *)keyFramesWithTimesAndStrokeEnds:(NSInteger)pairCount,...;
 
 + (instancetype)keyFrameWithTime:(NSInteger)time andAlpha:(CGFloat)alpha;
 + (instancetype)keyFrameWithTime:(NSInteger)time andCornerRadius:(CGFloat)cornerRadius;
@@ -38,6 +40,8 @@
 + (instancetype)keyFrameWithTime:(NSInteger)time andTransform3D:(IFTTTTransform3D *)transform;
 + (instancetype)keyFrameWithTime:(NSInteger)time andScale:(CGFloat)scale;
 + (instancetype)keyFrameWithTime:(NSInteger)time andConstraint:(CGFloat)constraint;
++ (instancetype)keyFrameWithTime:(NSInteger)time andStrokeStart:(CGFloat)strokeStart;
++ (instancetype)keyFrameWithTime:(NSInteger)time andStrokeEnd:(CGFloat)strokeEnd;
 
 - (id)initWithTime:(NSInteger)time andAlpha:(CGFloat)alpha;
 - (id)initWithTime:(NSInteger)time andCornerRadius:(CGFloat)cornerRadius;
@@ -48,6 +52,8 @@
 - (id)initWithTime:(NSInteger)time andTransform3D:(IFTTTTransform3D *)transform;
 - (id)initWithTime:(NSInteger)time andScale:(CGFloat)scale;
 - (id)initWithTime:(NSInteger)time andConstraint:(CGFloat)constraint;
+- (id)initWithTime:(NSInteger)time andStrokeStart:(CGFloat)strokeStart;
+- (id)initWithTime:(NSInteger)time andStrokeEnd:(CGFloat)strokeEnd;
 
 @property (assign, nonatomic) NSInteger time;
 

--- a/JazzHands/IFTTTAnimationKeyFrame.m
+++ b/JazzHands/IFTTTAnimationKeyFrame.m
@@ -246,6 +246,64 @@
     }
 }
 
++ (NSArray *)keyFramesWithTimesAndStrokeStarts:(NSInteger)pairCount, ... {
+
+    va_list argumentList;
+    
+    NSInteger time;
+    CGFloat strokeStart;
+    
+    if (pairCount > 0) {
+        NSMutableArray *keyFrames = [NSMutableArray arrayWithCapacity:(NSUInteger)pairCount];
+        
+        va_start(argumentList, pairCount);
+        
+        for (int i = 0; i < pairCount; i++) {
+            time = va_arg(argumentList, NSInteger);
+            strokeStart = (CGFloat)va_arg(argumentList, double);
+            IFTTTAnimationKeyFrame *keyFrame = [IFTTTAnimationKeyFrame keyFrameWithTime:time
+                                                                         andStrokeStart:strokeStart];
+            [keyFrames addObject:keyFrame];
+        }
+        
+        va_end(argumentList);
+        
+        return [NSArray arrayWithArray:keyFrames];
+    }
+    else {
+        return nil;
+    }
+}
+
++ (NSArray *)keyFramesWithTimesAndStrokeEnds:(NSInteger)pairCount, ... {
+    
+    va_list argumentList;
+    
+    NSInteger time;
+    CGFloat strokeEnd;
+    
+    if (pairCount > 0) {
+        NSMutableArray *keyFrames = [NSMutableArray arrayWithCapacity:(NSUInteger)pairCount];
+        
+        va_start(argumentList, pairCount);
+        
+        for (int i = 0; i < pairCount; i++) {
+            time = va_arg(argumentList, NSInteger);
+            strokeEnd = (CGFloat)va_arg(argumentList, double);
+            IFTTTAnimationKeyFrame *keyFrame = [IFTTTAnimationKeyFrame keyFrameWithTime:time
+                                                                           andStrokeEnd:strokeEnd];
+            [keyFrames addObject:keyFrame];
+        }
+        
+        va_end(argumentList);
+        
+        return [NSArray arrayWithArray:keyFrames];
+    }
+    else {
+        return nil;
+    }
+}
+
 + (instancetype)keyFrameWithTime:(NSInteger)time andAlpha:(CGFloat)alpha
 {
     IFTTTAnimationKeyFrame *keyFrame = [[self alloc] initWithTime:time
@@ -308,6 +366,20 @@
 + (instancetype)keyFrameWithTime:(NSInteger)time andConstraint:(CGFloat)constraint {
     IFTTTAnimationKeyFrame *keyFrame = [[self alloc] initWithTime:time
                                                     andConstraint:constraint];
+    
+    return keyFrame;
+}
+
++ (instancetype)keyFrameWithTime:(NSInteger)time andStrokeStart:(CGFloat)strokeStart {
+    IFTTTAnimationKeyFrame *keyFrame = [[self alloc] initWithTime:time
+                                                   andStrokeStart:strokeStart];
+    
+    return keyFrame;
+}
+
++ (instancetype)keyFrameWithTime:(NSInteger)time andStrokeEnd:(CGFloat)strokeEnd {
+    IFTTTAnimationKeyFrame *keyFrame = [[self alloc] initWithTime:time
+                                                     andStrokeEnd:strokeEnd];
     
     return keyFrame;
 }
@@ -396,6 +468,22 @@
 - (id)initWithTime:(NSInteger)time andConstraint:(CGFloat)constraint {
     if ((self = [self initWithTime:time])) {
         self.constraintConstant = constraint;
+    }
+    
+    return self;
+}
+
+- (id)initWithTime:(NSInteger)time andStrokeStart:(CGFloat)strokeStart {
+    if ((self = [self initWithTime:time])) {
+        self.strokeStart = strokeStart;
+    }
+    
+    return self;
+}
+
+- (id)initWithTime:(NSInteger)time andStrokeEnd:(CGFloat)strokeEnd {
+    if ((self = [self initWithTime:time])) {
+        self.strokeEnd = strokeEnd;
     }
     
     return self;

--- a/JazzHands/IFTTTFillColorAnimation.h
+++ b/JazzHands/IFTTTFillColorAnimation.h
@@ -1,0 +1,13 @@
+//
+//  IFTTTFillColorAnimation.h
+//  JazzHands
+//
+//  Created by Pierluigi D'Andrea on 07/05/15.
+//  Copyright (c) 2015 IFTTT Inc. All rights reserved.
+//
+
+#import "IFTTTAnimation.h"
+
+@interface IFTTTFillColorAnimation : IFTTTAnimation
+
+@end

--- a/JazzHands/IFTTTFillColorAnimation.m
+++ b/JazzHands/IFTTTFillColorAnimation.m
@@ -1,0 +1,63 @@
+//
+//  IFTTTFillColorAnimation.m
+//  JazzHands
+//
+//  Created by Pierluigi D'Andrea on 07/05/15.
+//  Copyright (c) 2015 IFTTT Inc. All rights reserved.
+//
+
+#import "IFTTTJazzHands.h"
+
+@implementation IFTTTFillColorAnimation
+
+- (id)initWithLayer:(CALayer *)layer {
+    NSCParameterAssert([layer isKindOfClass:CAShapeLayer.class]);
+    return [super initWithLayer:layer];
+}
+
+- (void)animate:(NSInteger)time
+{
+    if (self.keyFrames.count <= 1) return;
+    
+    IFTTTAnimationFrame *animationFrame = [self animationFrameForTime:time];
+    ((CAShapeLayer *)self.layer).fillColor = animationFrame.color.CGColor;
+}
+
+
+- (IFTTTAnimationFrame *)frameForTime:(NSInteger)time
+                        startKeyFrame:(IFTTTAnimationKeyFrame *)startKeyFrame
+                          endKeyFrame:(IFTTTAnimationKeyFrame *)endKeyFrame
+{
+    IFTTTAnimationFrame *animationFrame = [IFTTTAnimationFrame new];
+    
+    CGFloat startRed, startBlue, startGreen, startAlpha;
+    CGFloat endRed = 0, endBlue = 0, endGreen = 0, endAlpha = 0;
+    
+    if ([self iftttGetRed:&startRed green:&startGreen blue:&startBlue alpha:&startAlpha fromColor:startKeyFrame.color] &&
+        [self iftttGetRed:&endRed green:&endGreen blue:&endBlue alpha:&endAlpha fromColor:endKeyFrame.color]) {
+        CGFloat red = [self tweenValueForStartTime:startKeyFrame.time endTime:endKeyFrame.time startValue:startRed endValue:endRed atTime:time];
+        CGFloat green = [self tweenValueForStartTime:startKeyFrame.time endTime:endKeyFrame.time startValue:startGreen endValue:endGreen atTime:time];
+        CGFloat blue = [self tweenValueForStartTime:startKeyFrame.time endTime:endKeyFrame.time startValue:startBlue endValue:endBlue atTime:time];
+        CGFloat alpha = [self tweenValueForStartTime:startKeyFrame.time endTime:endKeyFrame.time startValue:startAlpha endValue:endAlpha atTime:time];
+        animationFrame.color = [UIColor colorWithRed:red green:green blue:blue alpha:alpha];
+    }
+    
+    return animationFrame;
+}
+
+- (BOOL) iftttGetRed:(CGFloat *)red green:(CGFloat *)green blue:(CGFloat *)blue alpha:(CGFloat *)alpha fromColor:(UIColor *)color {
+    CGFloat white;
+    
+    if ([color getRed:red green:green blue:blue alpha:alpha]) {
+        return YES;
+    } else if ([color getWhite:&white alpha:alpha]) {
+        *red = white;
+        *green = white;
+        *blue = white;
+        return YES;
+    }
+    
+    return NO;
+}
+
+@end

--- a/JazzHands/IFTTTJazzHands.h
+++ b/JazzHands/IFTTTJazzHands.h
@@ -26,3 +26,5 @@
 #import "IFTTTTransform3DAnimation.h"
 #import "IFTTTScaleAnimation.h"
 #import "IFTTTConstraintsAnimation.h"
+#import "IFTTTStrokeStartAnimation.h"
+#import "IFTTTStrokeEndAnimation.h"

--- a/JazzHands/IFTTTJazzHands.h
+++ b/JazzHands/IFTTTJazzHands.h
@@ -28,3 +28,4 @@
 #import "IFTTTConstraintsAnimation.h"
 #import "IFTTTStrokeStartAnimation.h"
 #import "IFTTTStrokeEndAnimation.h"
+#import "IFTTTFillColorAnimation.h"

--- a/JazzHands/IFTTTStrokeEndAnimation.h
+++ b/JazzHands/IFTTTStrokeEndAnimation.h
@@ -1,0 +1,13 @@
+//
+//  IFTTTStrokeEndAnimation.h
+//  JazzHands
+//
+//  Created by Pierluigi D'Andrea on 06/05/15.
+//  Copyright (c) 2015 IFTTT Inc. All rights reserved.
+//
+
+#import "IFTTTAnimation.h"
+
+@interface IFTTTStrokeEndAnimation : IFTTTAnimation
+
+@end

--- a/JazzHands/IFTTTStrokeEndAnimation.m
+++ b/JazzHands/IFTTTStrokeEndAnimation.m
@@ -11,7 +11,7 @@
 @implementation IFTTTStrokeEndAnimation
 
 - (id)initWithLayer:(CALayer *)layer {
-    NSCAssert([self.layer isKindOfClass:CAShapeLayer.class], @"strokeEnd is a CAShapeLayer property");
+    NSCParameterAssert([layer isKindOfClass:CAShapeLayer.class]);
     return [super initWithLayer:layer];
 }
 

--- a/JazzHands/IFTTTStrokeEndAnimation.m
+++ b/JazzHands/IFTTTStrokeEndAnimation.m
@@ -1,0 +1,41 @@
+//
+//  IFTTTStrokeEndAnimation.m
+//  JazzHands
+//
+//  Created by Pierluigi D'Andrea on 06/05/15.
+//  Copyright (c) 2015 IFTTT Inc. All rights reserved.
+//
+
+#import "IFTTTJazzHands.h"
+
+@implementation IFTTTStrokeEndAnimation
+
+- (id)initWithLayer:(CALayer *)layer {
+    NSCAssert([self.layer isKindOfClass:CAShapeLayer.class], @"strokeEnd is a CAShapeLayer property");
+    return [super initWithLayer:layer];
+}
+
+- (void)animate:(NSInteger)time
+{
+    if (self.keyFrames.count <= 1) return;
+    
+    IFTTTAnimationFrame *animationFrame = [self animationFrameForTime:time];
+    ((CAShapeLayer *)self.layer).strokeEnd = animationFrame.strokeEnd;
+}
+
+- (IFTTTAnimationFrame *)frameForTime:(NSInteger)time
+                        startKeyFrame:(IFTTTAnimationKeyFrame *)startKeyFrame
+                          endKeyFrame:(IFTTTAnimationKeyFrame *)endKeyFrame
+{
+    IFTTTAnimationFrame *animationFrame = [IFTTTAnimationFrame new];
+    animationFrame.strokeEnd = [self tweenValueForStartTime:startKeyFrame.time
+                                                    endTime:endKeyFrame.time
+                                                 startValue:startKeyFrame.strokeEnd
+                                                   endValue:endKeyFrame.strokeEnd
+                                                     atTime:time];
+    
+    return animationFrame;
+}
+
+
+@end

--- a/JazzHands/IFTTTStrokeStartAnimation.h
+++ b/JazzHands/IFTTTStrokeStartAnimation.h
@@ -1,0 +1,13 @@
+//
+//  IFTTTStrokeStartAnimation.h
+//  JazzHands
+//
+//  Created by Pierluigi D'Andrea on 06/05/15.
+//  Copyright (c) 2015 IFTTT Inc. All rights reserved.
+//
+
+#import "IFTTTAnimation.h"
+
+@interface IFTTTStrokeStartAnimation : IFTTTAnimation
+
+@end

--- a/JazzHands/IFTTTStrokeStartAnimation.m
+++ b/JazzHands/IFTTTStrokeStartAnimation.m
@@ -1,0 +1,41 @@
+//
+//  IFTTTStrokeStartAnimation.m
+//  JazzHands
+//
+//  Created by Pierluigi D'Andrea on 06/05/15.
+//  Copyright (c) 2015 IFTTT Inc. All rights reserved.
+//
+
+#import "IFTTTJazzHands.h"
+
+@implementation IFTTTStrokeStartAnimation
+
+- (id)initWithLayer:(CALayer *)layer {
+    NSCAssert([self.layer isKindOfClass:CAShapeLayer.class], @"strokeStart is a CAShapeLayer property");
+    return [super initWithLayer:layer];
+}
+
+- (void)animate:(NSInteger)time
+{
+    if (self.keyFrames.count <= 1) return;
+    
+    IFTTTAnimationFrame *animationFrame = [self animationFrameForTime:time];
+    ((CAShapeLayer *)self.layer).strokeStart = animationFrame.strokeStart;
+}
+
+- (IFTTTAnimationFrame *)frameForTime:(NSInteger)time
+                        startKeyFrame:(IFTTTAnimationKeyFrame *)startKeyFrame
+                          endKeyFrame:(IFTTTAnimationKeyFrame *)endKeyFrame
+{
+    IFTTTAnimationFrame *animationFrame = [IFTTTAnimationFrame new];
+    animationFrame.strokeStart = [self tweenValueForStartTime:startKeyFrame.time
+                                                      endTime:endKeyFrame.time
+                                                   startValue:startKeyFrame.strokeStart
+                                                     endValue:endKeyFrame.strokeStart
+                                                       atTime:time];
+    
+    return animationFrame;
+}
+
+
+@end

--- a/JazzHands/IFTTTStrokeStartAnimation.m
+++ b/JazzHands/IFTTTStrokeStartAnimation.m
@@ -11,7 +11,7 @@
 @implementation IFTTTStrokeStartAnimation
 
 - (id)initWithLayer:(CALayer *)layer {
-    NSCAssert([self.layer isKindOfClass:CAShapeLayer.class], @"strokeStart is a CAShapeLayer property");
+    NSCParameterAssert([layer isKindOfClass:CAShapeLayer.class]);
     return [super initWithLayer:layer];
 }
 


### PR DESCRIPTION
Hi, in this PR I've added an initializer, with a `CALayer`, to `IFTTTAnimation` and 3 `IFTTTAnimation` subclasses to animate:

* `CAShapeLayer.strokeStart`
* `CAShapeLayer.strokeEnd`
* `CAShapeLayer.fillColor`

Here's an example animation for `strokeEnd` (from 1 to 0) and `fillColor` (from blue to clear):

![anim1](https://cloud.githubusercontent.com/assets/3475083/7511628/9cf8a8fe-f4a6-11e4-92e9-df8e499d7a18.gif)
