### PR TITLE
switched back to #import instead of @import module

### DIFF
--- a/Example/JazzHandsTests/JazzHandsTests.m
+++ b/Example/JazzHandsTests/JazzHandsTests.m
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 IFTTT Inc. All rights reserved.
 //
 
-@import XCTest;
+#import <XCTest/XCTest.h>
 #import <IFTTTJazzHands.h>
 #import <FBSnapshotTestCase.h>
 #import <KIF.h>

--- a/JazzHands/IFTTTAnimatedScrollViewController.h
+++ b/JazzHands/IFTTTAnimatedScrollViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 IFTTT Inc. All rights reserved.
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 @class IFTTTAnimator;
 
 @protocol IFTTTAnimatedScrollViewControllerDelegate;

--- a/JazzHands/IFTTTAnimation.h
+++ b/JazzHands/IFTTTAnimation.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2013 IFTTT Inc. All rights reserved.
 //
 
-@import Foundation;
-@import UIKit;
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 @class IFTTTAnimationKeyFrame, IFTTTAnimationFrame;
 
 @interface IFTTTAnimation : NSObject

--- a/JazzHands/IFTTTAnimationFrame.h
+++ b/JazzHands/IFTTTAnimationFrame.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 IFTTT Inc. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 @class IFTTTTransform3D;
 
 @interface IFTTTAnimationFrame : NSObject

--- a/JazzHands/IFTTTEasingFunction.h
+++ b/JazzHands/IFTTTEasingFunction.h
@@ -15,8 +15,8 @@
 // Copied from Robert Böhnke's RBBAnimation, original available here:
 // <https://github.com/robb/RBBAnimation/blob/a29cafe2fa91e62573cc9967990b0ad2a6b17a76/RBBAnimation/RBBEasingFunction.h>
 
-@import UIKit;
-@import QuartzCore;
+#import <UIKit/UIKit.h>
+#import <QuartzCore/QuartzCore.h>
 
 typedef CGFloat (^IFTTTEasingFunction) (CGFloat t);
 

--- a/JazzHands/IFTTTJazzHands.h
+++ b/JazzHands/IFTTTJazzHands.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-@import Foundation;
-@import UIKit;
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 #import "IFTTTAnimation.h"
 #import "IFTTTAnimationKeyFrame.h"


### PR DESCRIPTION
Hello,

Can you switch back to the old-school #import? We have a project where 'modules' are disabled by some reasons and maybe we're not only one.
As far as I understand how it works, you don't actually need to use the @import keyword. Here is a good [explanation](http://stackoverflow.com/questions/18947516/import-vs-import-ios-7):
> If you opt-in to using modules, all #import and #include directives are mapped to use @import automatically. That means that you don't have to change your source code (or the source code of libraries that you download from elsewhere). Supposedly using modules improves the build performance too, especially if you haven't been using PCHs well or if your project has many small source files.

Thank you!

Artem