### PR TITLE
Implement IFTTTMaskEffectRevealFromCenter animation in IFTTTMaskAnimation 

### DIFF
--- a/JazzHands/IFTTTMaskAnimation.h
+++ b/JazzHands/IFTTTMaskAnimation.h
@@ -14,7 +14,8 @@ typedef NS_ENUM(NSUInteger, IFTTTMaskEffect)
     IFTTTMaskEffectRevealFromLeft,
     IFTTTMaskEffectRevealFromBottom,
     IFTTTMaskEffectRevealFromRight,
-    IFTTTMaskEffectRevealFromCenter
+    IFTTTMaskEffectRevealFromCenterToCircle,
+    IFTTTMaskEffectRevealFromCenterToBounds
 };
 
 @interface IFTTTMaskAnimation : IFTTTAnimation <IFTTTAnimatable>

--- a/JazzHands/IFTTTMaskAnimation.h
+++ b/JazzHands/IFTTTMaskAnimation.h
@@ -8,18 +8,19 @@
 
 #import "IFTTTAnimation.h"
 
-typedef NS_ENUM(NSUInteger, IFTTTMaskSwipeDirection)
+typedef NS_ENUM(NSUInteger, IFTTTMaskEffect)
 {
-    IFTTTMaskSwipeFromTop,
-    IFTTTMaskSwipeFromLeft,
-    IFTTTMaskSwipeFromBottom,
-    IFTTTMaskSwipeFromRight
+    IFTTTMaskEffectRevealFromTop,
+    IFTTTMaskEffectRevealFromLeft,
+    IFTTTMaskEffectRevealFromBottom,
+    IFTTTMaskEffectRevealFromRight,
+    IFTTTMaskEffectRevealFromCenter
 };
 
 @interface IFTTTMaskAnimation : IFTTTAnimation <IFTTTAnimatable>
 
-- (instancetype)initWithView:(UIView *)view direction:(IFTTTMaskSwipeDirection)direction;
-+ (instancetype)animationWithView:(UIView *)view direction:(IFTTTMaskSwipeDirection)direction;
+- (instancetype)initWithView:(UIView *)view maskEffect:(IFTTTMaskEffect)maskEffect;
++ (instancetype)animationWithView:(UIView *)view maskEffect:(IFTTTMaskEffect)maskEffect;
 
 - (void)addKeyframeForTime:(CGFloat)time visibility:(CGFloat)percent;
 - (void)addKeyframeForTime:(CGFloat)time visibility:(CGFloat)percent withEasingFunction:(IFTTTEasingFunction)easingFunction;

--- a/JazzHands/IFTTTMaskAnimation.m
+++ b/JazzHands/IFTTTMaskAnimation.m
@@ -82,10 +82,21 @@
             maskPath = [UIBezierPath bezierPathWithRect:maskedRect];
             break;
         }
-        case IFTTTMaskEffectRevealFromCenter:
+        case IFTTTMaskEffectRevealFromCenterToCircle:
         {
             CGPoint center = CGPointMake((CGRectGetWidth(maskedRect) / 2.f), (CGRectGetHeight(maskedRect) / 2.f));
-            CGFloat radius = MAX(center.x, center.y);
+            CGFloat radius = MIN(center.x, center.y);
+            maskPath = [UIBezierPath bezierPathWithArcCenter:center
+                                                      radius:radius * visibilityPercent
+                                                  startAngle:0.f
+                                                    endAngle:M_PI * 2.f
+                                                   clockwise:YES];
+            break;
+        }
+        case IFTTTMaskEffectRevealFromCenterToBounds:
+        {
+            CGPoint center = CGPointMake((CGRectGetWidth(maskedRect) / 2.f), (CGRectGetHeight(maskedRect) / 2.f));
+            CGFloat radius = sqrt(pow(center.x, 2) + pow(center.y, 2));
             maskPath = [UIBezierPath bezierPathWithArcCenter:center
                                                       radius:radius * visibilityPercent
                                                   startAngle:0.f


### PR DESCRIPTION
Not sure if anyone else would find this useful, but I implemented a circular mask animation. This animation will mask a view to a circle starting in the center at visibility 0 and work it's way to the outside at visibility 1.0.

Initially I thought I could use the corner radius animation for what I needed, but I wanted the radius to be calculated automatically.