### PR TITLE
perform setup in viewWillAppear instead of viewDidAppear

### DIFF
--- a/JazzHands/IFTTTAnimatedPagingScrollViewController.m
+++ b/JazzHands/IFTTTAnimatedPagingScrollViewController.m
@@ -83,9 +83,9 @@
     [self.view addConstraint:[NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeHeight multiplier:1.f constant:0.f]];
 }
 
-- (void)viewDidAppear:(BOOL)animated
+- (void)viewWillAppear:(BOOL)animated
 {
-    [super viewDidAppear:animated];
+    [super viewWillAppear:animated];
     
     for (IFTTTScrollViewPageConstraintAnimation *animation in self.scrollViewPageConstraintAnimations) {
         animation.pageWidth = self.pageWidth;


### PR DESCRIPTION
Some subviews flicker shortly at startup when the setup is in viewDidAppear
